### PR TITLE
'const length = val.length' breaking build #6'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ module.exports = function isNumberLike (val) {
   if (typeof val === 'function' || val instanceof Array) {
     return false
   }
-  const length = val.length
+  var length = val.length
   if (!length) {
     return isNumber(val)
   }


### PR DESCRIPTION
Changed the use of es6 const for var so that all node versions can work with it.