### PR TITLE
Mitigate against NODE-SECURITY-606

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1427,7 +1427,7 @@
           "optional": true
         },
         "sshpk": {
-          "version": "1.13.0",
+          "version": "1.14.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2893,8 +2893,8 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "dependencies": {


### PR DESCRIPTION
Versions of sshpk before 1.14.1 are vulnerable to regular expression denial of service when parsing crafted invalid public keys.